### PR TITLE
fix: autofirma hm module in standalone mode. Closes #55

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,19 +145,23 @@
           nixos-dnieremote-config-wifiport = pkgs.callPackage ./nix/tests/nixos/dnieremote/config/wifiport.nix { inherit self; };
 
           # Home Manager Modules
-          ## AutoFirma
+          ## HM installed as a NixOS Module
+          ### AutoFirma
           hm-as-nixos-module-autofirma-cli-sign-document = pkgs.callPackage ./nix/tests/hm-as-nixos-module/autofirma/cli/sign-document.nix { inherit self home-manager; };
           hm-as-nixos-module-autofirma-firefoxIntegration-protocol-handler = pkgs.callPackage ./nix/tests/hm-as-nixos-module/autofirma/firefoxIntegration/protocol-handler { inherit self home-manager; };
           hm-as-nixos-module-autofirma-firefoxIntegration-connection-method-websocket = pkgs.callPackage ./nix/tests/hm-as-nixos-module/autofirma/firefoxIntegration/connection-method/websocket { inherit self home-manager; };
           hm-as-nixos-module-autofirma-firefoxIntegration-connection-method-xhr = pkgs.callPackage ./nix/tests/hm-as-nixos-module/autofirma/firefoxIntegration/connection-method/xhr { inherit self home-manager; };
           hm-as-nixos-module-autofirma-firefoxIntegration-connection-method-auxiliary-servers = pkgs.callPackage ./nix/tests/hm-as-nixos-module/autofirma/firefoxIntegration/connection-method/auxiliary-servers { inherit self home-manager; };
-          ## Configurador FNMT-RCM
+          ### Configurador FNMT-RCM
           hm-as-nixos-module-configuradorfnmt-firefoxIntegration-request = pkgs.callPackage ./nix/tests/hm-as-nixos-module/configuradorfnmt/firefoxIntegration/request-certificate.nix { inherit self home-manager; };
-          ## DNIe Remote
+          ### DNIe Remote
           hm-as-nixos-module-dnieremote-config-jumpintro-wifi = pkgs.callPackage ./nix/tests/hm-as-nixos-module/dnieremote/config/jumpintro-wifi.nix { inherit self home-manager; };
           hm-as-nixos-module-dnieremote-config-jumpintro-usb = pkgs.callPackage ./nix/tests/hm-as-nixos-module/dnieremote/config/jumpintro-usb.nix { inherit self home-manager; };
           hm-as-nixos-module-dnieremote-config-jumpintro-no = pkgs.callPackage ./nix/tests/hm-as-nixos-module/dnieremote/config/jumpintro-no.nix { inherit self home-manager; };
           hm-as-nixos-module-dnieremote-config-wifiport = pkgs.callPackage ./nix/tests/hm-as-nixos-module/dnieremote/config/wifiport.nix { inherit self home-manager; };
+          # HM standalone installation
+          ### AutoFirma
+          hm-standalone-autofirma-cli-sign-document = pkgs.callPackage ./nix/tests/hm-standalone/autofirma/cli/sign-document.nix { inherit self home-manager; };
         };
       };
     };

--- a/nix/autofirma/hm-module.nix
+++ b/nix/autofirma/hm-module.nix
@@ -1,6 +1,6 @@
 inputs: {
   pkgs,
-  osConfig ? null,
+  osConfig,
   config,
   lib,
   ...

--- a/nix/autofirma/hm-module.nix
+++ b/nix/autofirma/hm-module.nix
@@ -1,12 +1,13 @@
 inputs: {
   pkgs,
-  osConfig,
+  osConfig ? null,
   config,
   lib,
   ...
 }:
 with lib; let
   cfg = config.programs.autofirma;
+  ca-certificates = if osConfig != null then osConfig.environment.etc."ssl/certs/ca-certificates.crt".source else "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
   inherit (pkgs.stdenv.hostPlatform) system;
 in {
   options.programs.autofirma.truststore = {
@@ -14,7 +15,7 @@ in {
     finalPackage = mkOption {
       type = types.package;
       readOnly = true;
-      default = cfg.truststore.package.override { caBundle = osConfig.environment.etc."ssl/certs/ca-certificates.crt".source; };
+      default = cfg.truststore.package.override { caBundle = ca-certificates; };
       defaultText =
         literalExpression
         "`programs.autofirma.truststore.package` with applied configuration";

--- a/nix/tests/_common/hm-standalone/autofirma-user.nix
+++ b/nix/tests/_common/hm-standalone/autofirma-user.nix
@@ -13,15 +13,6 @@ in
       extra-experimental-features = [ "nix-command" "flakes" ];
     };
 
-    # home-manager.users.autofirma-user = {config, ... }: {
-    #   xsession.enable = true;
-    #   xsession.initExtra = ''
-    #     xhost +SI:localuser:root
-    #   '';
-
-    #   home.stateVersion = stateVersion;
-    # };
-
     environment.systemPackages = with pkgs; [
       xorg.xhost.out
     ];

--- a/nix/tests/_common/hm-standalone/autofirma-user.nix
+++ b/nix/tests/_common/hm-standalone/autofirma-user.nix
@@ -1,0 +1,31 @@
+{ pkgs, lib, ... }:
+let
+  stateVersion = "${lib.versions.major lib.version}.${lib.versions.minor lib.version}";
+in
+{
+    test-support.displayManager.auto.user = "autofirma-user";
+
+    users.users.autofirma-user = {
+      isNormalUser = true;
+    };
+
+    nix.settings = {
+      extra-experimental-features = [ "nix-command" "flakes" ];
+    };
+
+    # home-manager.users.autofirma-user = {config, ... }: {
+    #   xsession.enable = true;
+    #   xsession.initExtra = ''
+    #     xhost +SI:localuser:root
+    #   '';
+
+    #   home.stateVersion = stateVersion;
+    # };
+
+    environment.systemPackages = with pkgs; [
+      xorg.xhost.out
+    ];
+
+    system.stateVersion = stateVersion;
+}
+

--- a/nix/tests/hm-standalone/autofirma/cli/sign-document.nix
+++ b/nix/tests/hm-standalone/autofirma/cli/sign-document.nix
@@ -1,0 +1,48 @@
+{ self, pkgs, home-manager, lib }:
+let
+  openssl = lib.getExe pkgs.openssl;
+  stateVersion = "${lib.versions.major lib.version}.${lib.versions.minor lib.version}";
+  homeManagerStandaloneConfiguration = home-manager.lib.homeManagerConfiguration {
+    inherit pkgs;
+    modules = [
+      self.homeManagerModules.autofirma
+      {
+        home.username = "autofirma-user";
+        home.homeDirectory = "/home/autofirma-user";
+        home.stateVersion = "${stateVersion}";
+
+        programs.autofirma.enable = true;
+      }
+    ];
+  };
+in
+
+pkgs.nixosTest {
+  name = "test-hm-standalone-autofirma-cli-sign-document";
+  nodes.machine = { config, pkgs, modulesPath, ... }: {
+    imports = [
+      (modulesPath + "./../tests/common/x11.nix")
+      ../../../_common/hm-standalone/autofirma-user.nix
+    ];
+
+    environment.systemPackages = [
+      homeManagerStandaloneConfiguration.activationPackage
+    ];
+
+    system.stateVersion = stateVersion;
+  };
+
+  testScript = ''
+    def user_cmd(cmd):
+      return f"su -l autofirma-user --shell /bin/sh -c $'export XDG_RUNTIME_DIR=/run/user/$UID ; {cmd}'"
+
+    machine.wait_for_x()
+    machine.succeed(user_cmd('home-manager-generation'))
+
+    machine.succeed(user_cmd('echo "NixOS AutoFirma Sign Test" > document.txt'))
+    machine.succeed(user_cmd('${openssl} req -x509 -newkey rsa:2048 -keyout private.key -out certificate.crt -days 365 -nodes -subj "/C=ES/O=TEST AUTOFIRMA NIX/OU=DNIE/CN=AC DNIE 004" -passout pass:1234'))
+    machine.succeed(user_cmd('${openssl} pkcs12 -export -out certificate.p12 -inkey private.key -in certificate.crt -name "testcert" -password pass:1234'))
+
+    machine.succeed(user_cmd('autofirma sign -store pkcs12:certificate.p12 -i document.txt -o document.txt.sign -filter alias.contains=testcert -password 1234 -xml'))
+  '';
+}


### PR DESCRIPTION
Autofirma HM module expected osConfig to extract the user's caBundle. In standalone mode `osConfig = null` so nixpkgs caBundle is used instead.