### PR TITLE
create autofirma cert result is 0 (exit) when the files already existed

### DIFF
--- a/nix/autofirma/create-autofirma-cert
+++ b/nix/autofirma/create-autofirma-cert
@@ -98,4 +98,8 @@ function do_init {
 }
 
 # If any required cert or key is missing rebuild it
-[[ ! -r "${_autofirma_ca}" || ! -r "${_autofirma_pfx}" ]] && do_init || true
+if [[ ! -r "${_autofirma_ca}" || ! -r "${_autofirma_pfx}" ]]; then
+    do_init
+else
+    true  # Explicit success exit code
+fi

--- a/nix/autofirma/create-autofirma-cert
+++ b/nix/autofirma/create-autofirma-cert
@@ -98,5 +98,4 @@ function do_init {
 }
 
 # If any required cert or key is missing rebuild it
-[[ ! -r "${_autofirma_ca}" || ! -r "${_autofirma_pfx}" ]] && \
-  do_init
+[[ ! -r "${_autofirma_ca}" || ! -r "${_autofirma_pfx}" ]] && do_init || true


### PR DESCRIPTION
I started having a problem recreating home-manager environment with autofirma since yesterday.

After some debugging I found out that the last line of the script 'autofirma/create-autofirma-cert' exited the script with status 1 if the generated certs already existed.
Home manager activating process does not like this result.

I'm quite confident this change fixes the issue.

I hope you accept it.