### PR TITLE
feat(hm): honor VERBOSE_ARG in activation script

### DIFF
--- a/nix/autofirma/create-autofirma-cert
+++ b/nix/autofirma/create-autofirma-cert
@@ -1,3 +1,13 @@
+if [[ "$1" == '--verbose' ]]; then
+	shift
+	set -o verbose
+fi
+
+if [[ "$1" == '--dry-run' ]]; then
+	shift
+	set -o noexec
+fi
+
 _autofirma_dir="$1"
 _autofirma_ca="${_autofirma_dir}/AutoFirma_ROOT.cer"
 _autofirma_pfx="${_autofirma_dir}/autofirma.pfx"

--- a/nix/autofirma/create-autofirma-cert
+++ b/nix/autofirma/create-autofirma-cert
@@ -3,11 +3,6 @@ if [[ "$1" == '--verbose' ]]; then
 	set -o verbose
 fi
 
-if [[ "$1" == '--dry-run' ]]; then
-	shift
-	set -o noexec
-fi
-
 _autofirma_dir="$1"
 _autofirma_ca="${_autofirma_dir}/AutoFirma_ROOT.cer"
 _autofirma_pfx="${_autofirma_dir}/autofirma.pfx"

--- a/nix/autofirma/hm-module.nix
+++ b/nix/autofirma/hm-module.nix
@@ -70,7 +70,7 @@ in {
   config = mkIf cfg.enable {
     home.activation.createAutoFirmaCert = lib.hm.dag.entryAfter ["writeBoundary"] ''
       verboseEcho Running create-autofirma-cert
-      run ${lib.getExe create-autofirma-cert} $VERBOSE_ARG ''${DRY_RUN:+--dry-run} ${config.home.homeDirectory}/.afirma/AutoFirma
+      run ${lib.getExe create-autofirma-cert} $VERBOSE_ARG ${config.home.homeDirectory}/.afirma/AutoFirma
     '';
     home.packages = [cfg.finalPackage];
     programs.firefox.policies.Certificates = mkIf anyFirefoxIntegrationProfileIsEnabled {

--- a/nix/autofirma/hm-module.nix
+++ b/nix/autofirma/hm-module.nix
@@ -70,7 +70,7 @@ in {
   config = mkIf cfg.enable {
     home.activation.createAutoFirmaCert = lib.hm.dag.entryAfter ["writeBoundary"] ''
       verboseEcho Running create-autofirma-cert
-      run ${lib.getExe create-autofirma-cert} $VERBOSE_ARG '${DRY_RUN:+--dry-run}' ${config.home.homeDirectory}/.afirma/AutoFirma
+      run ${lib.getExe create-autofirma-cert} $VERBOSE_ARG ''${DRY_RUN:+--dry-run} ${config.home.homeDirectory}/.afirma/AutoFirma
     '';
     home.packages = [cfg.finalPackage];
     programs.firefox.policies.Certificates = mkIf anyFirefoxIntegrationProfileIsEnabled {

--- a/nix/autofirma/hm-module.nix
+++ b/nix/autofirma/hm-module.nix
@@ -70,7 +70,7 @@ in {
   config = mkIf cfg.enable {
     home.activation.createAutoFirmaCert = lib.hm.dag.entryAfter ["writeBoundary"] ''
       verboseEcho Running create-autofirma-cert
-      run ${lib.getExe create-autofirma-cert} $VERBOSE_ARG $DRY_RUN ${config.home.homeDirectory}/.afirma/AutoFirma
+      run ${lib.getExe create-autofirma-cert} $VERBOSE_ARG \${DRY_RUN:+--dry-run} ${config.home.homeDirectory}/.afirma/AutoFirma
     '';
     home.packages = [cfg.finalPackage];
     programs.firefox.policies.Certificates = mkIf anyFirefoxIntegrationProfileIsEnabled {

--- a/nix/autofirma/hm-module.nix
+++ b/nix/autofirma/hm-module.nix
@@ -70,7 +70,7 @@ in {
   config = mkIf cfg.enable {
     home.activation.createAutoFirmaCert = lib.hm.dag.entryAfter ["writeBoundary"] ''
       verboseEcho Running create-autofirma-cert
-      run ${lib.getExe create-autofirma-cert} $VERBOSE_ARG \${DRY_RUN:+--dry-run} ${config.home.homeDirectory}/.afirma/AutoFirma
+      run ${lib.getExe create-autofirma-cert} $VERBOSE_ARG '${DRY_RUN:+--dry-run}' ${config.home.homeDirectory}/.afirma/AutoFirma
     '';
     home.packages = [cfg.finalPackage];
     programs.firefox.policies.Certificates = mkIf anyFirefoxIntegrationProfileIsEnabled {

--- a/nix/autofirma/hm-module.nix
+++ b/nix/autofirma/hm-module.nix
@@ -69,7 +69,8 @@ in {
   };
   config = mkIf cfg.enable {
     home.activation.createAutoFirmaCert = lib.hm.dag.entryAfter ["writeBoundary"] ''
-      run ${lib.getExe create-autofirma-cert} ${config.home.homeDirectory}/.afirma/AutoFirma
+      verboseEcho Running create-autofirma-cert
+      run ${lib.getExe create-autofirma-cert} $VERBOSE_ARG $DRY_RUN ${config.home.homeDirectory}/.afirma/AutoFirma
     '';
     home.packages = [cfg.finalPackage];
     programs.firefox.policies.Certificates = mkIf anyFirefoxIntegrationProfileIsEnabled {


### PR DESCRIPTION
See [here](https://nix-community.github.io/home-manager/options.xhtml#opt-home.activation) for the rationale.

The `$VERBOSE_ARG` thingy is clear for me, since I use it in my Emacs HM activation script.
~~The `$DRY_RUN` thingy requires more investigation.~~