### PR TITLE
feat: monitor upstream releases pages

### DIFF
--- a/.github/urlwatch/urls.yml
+++ b/.github/urlwatch/urls.yml
@@ -1,0 +1,29 @@
+name: "AutoFirma"
+url: "https://firmaelectronica.gob.es/Home/Descargas.html"
+ssl_no_verify: true
+filter:
+  - xpath: //a
+  - grep: "AutoFirma"
+  - grep: "Linux"
+  - xpath: //@href
+---
+name: "Configurador FNMT-RCM"
+url: "https://www.sede.fnmt.gob.es/descargas/descarga-software/instalacion-software-generacion-de-claves"
+ssl_no_verify: true
+filter:
+  - xpath: //a
+  - grep: "Configurador"
+  - grep: "FNMT-RCM"
+  - grep: "Linux"
+  - xpath: //@href
+---
+name: "DNIeRemote"
+url: "https://www.dnielectronico.es/PortalDNIe/PRF1_Cons02.action?pag=REF_1015&id_menu=67"
+ssl_no_verify: true
+filter:
+  - xpath: //a
+  - grep: "DNIe"
+  - grep: "Remote"
+  - grep: "Linux"
+  - xpath: //@href
+---

--- a/.github/urlwatch/urlwatch.yml
+++ b/.github/urlwatch/urlwatch.yml
@@ -1,7 +1,7 @@
 display:
   empty-diff: false
   error: true
-  new: false
+  new: true
   unchanged: false
 job_defaults:
   all: {}

--- a/.github/urlwatch/urlwatch.yml
+++ b/.github/urlwatch/urlwatch.yml
@@ -1,5 +1,5 @@
 display:
-  empty-diff: true
+  empty-diff: false
   error: true
   new: false
   unchanged: false

--- a/.github/urlwatch/urlwatch.yml
+++ b/.github/urlwatch/urlwatch.yml
@@ -1,0 +1,114 @@
+display:
+  empty-diff: true
+  error: true
+  new: false
+  unchanged: false
+job_defaults:
+  all: {}
+  browser: {}
+  shell: {}
+  url: {}
+report:
+  discord:
+    colored: true
+    embed: false
+    enabled: false
+    max_message_length: 2000
+    subject: '{count} changes: {jobs}'
+    webhook_url: ''
+  email:
+    enabled: false
+    from: ''
+    html: false
+    method: smtp
+    reply_to: ''
+    sendmail:
+      path: sendmail
+    smtp:
+      auth: true
+      host: localhost
+      port: 25
+      starttls: true
+      user: ''
+    subject: '{count} changes: {jobs}'
+    to: ''
+  gotify:
+    enabled: false
+    priority: 0
+    server_url: ''
+    title: null
+    token: ''
+  html:
+    diff: unified
+    separate: false
+  ifttt:
+    enabled: false
+    event: ''
+    key: ''
+  mailgun:
+    api_key: ''
+    domain: ''
+    enabled: false
+    from_mail: ''
+    from_name: ''
+    region: us
+    subject: '{count} changes: {jobs}'
+    to: ''
+  markdown:
+    details: true
+    footer: true
+    minimal: false
+    separate: false
+  matrix:
+    access_token: ''
+    enabled: false
+    homeserver: ''
+    room_id: ''
+  mattermost:
+    enabled: false
+    max_message_length: 40000
+    webhook_url: ''
+  prowl:
+    api_key: ''
+    application: ''
+    enabled: false
+    priority: 0
+    subject: '{count} changes: {jobs}'
+  pushbullet:
+    api_key: ''
+    enabled: false
+  pushover:
+    app: ''
+    device: null
+    enabled: false
+    priority: normal
+    sound: spacealarm
+    user: ''
+  shell:
+    command: ''
+    enabled: false
+    ignore_stderr: false
+    ignore_stdout: true
+  slack:
+    enabled: false
+    max_message_length: 40000
+    webhook_url: ''
+  stdout:
+    color: false
+    enabled: true
+  telegram:
+    bot_token: ''
+    chat_id: ''
+    enabled: false
+    monospace: false
+    silent: false
+  text:
+    details: true
+    footer: true
+    line_length: 75
+    minimal: false
+    separate: false
+  xmpp:
+    enabled: false
+    recipient: ''
+    sender: ''

--- a/.github/workflows/urlwatch.yml
+++ b/.github/workflows/urlwatch.yml
@@ -2,7 +2,7 @@ name: Monitor Upstream Releases
 
 on:
   schedule:
-    - cron: '10 10 * * *'  # Daily at 4:10am
+    - cron: '10 10 * * *'  # Daily at 10:10
   workflow_dispatch:
 
 permissions:
@@ -78,7 +78,7 @@ jobs:
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'New official releases published',
+              title: 'New official releases available 🎉',
               body: body,
               labels: ['upstream', 'update']  # Add labels
             });

--- a/.github/workflows/urlwatch.yml
+++ b/.github/workflows/urlwatch.yml
@@ -1,0 +1,84 @@
+name: URLWatch Monitor
+
+on:
+  schedule:
+    - cron: '10 4 * * *'  # Daily at 4:10am
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: write
+  issues: write
+
+jobs:
+  urlwatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install urlwatch
+        run: pip install urlwatch
+
+      - name: Setup config directories
+        run: |
+          mkdir -p ~/.config/urlwatch ~/.cache/urlwatch
+          cp -r .github/urlwatch/* ~/.config/urlwatch/
+
+      - name: Get last successful run ID
+        id: last-run
+        uses: actions/github-script@v6
+        continue-on-error: true
+        with:
+          script: |
+            const response = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'urlwatch.yml',
+              status: 'success',
+              per_page: 1
+            });
+            core.setOutput('run_id', response.data.workflow_runs[0]?.id || 0);
+
+      - name: Download previous cache
+        uses: actions/download-artifact@v4
+        with:
+          name: urlwatch-cache
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.last-run.outputs.run_id }}
+        if: ${{ steps.last-run.outputs.run_id != 0 }}
+
+      - name: Run urlwatch and capture output
+        id: run-urlwatch
+        run: |
+          # Move downloaded cache if exists
+          if [ -f cache.db ]; then
+            mv cache.db ~/.cache/urlwatch/
+          fi
+          
+          # Run urlwatch and capture output
+          output=$(urlwatch)
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$output" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Upload new cache
+        uses: actions/upload-artifact@v3
+        with:
+          name: urlwatch-cache
+          path: ~/.cache/urlwatch/cache.db
+
+      - name: Create Issue if changes detected
+        if: ${{ steps.run-urlwatch.outputs.output != '' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const output = `${{ steps.run-urlwatch.outputs.output }}`;
+            const body = `\`\`\`\n${output}\n\`\`\``;  # Wrap output in a Markdown code block
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Updates detected by urlwatch',
+              body: body,
+              labels: ['upstream', 'update']  # Add labels
+            });

--- a/.github/workflows/urlwatch.yml
+++ b/.github/workflows/urlwatch.yml
@@ -1,4 +1,4 @@
-name: URLWatch Monitor
+name: Monitor Upstream Releases
 
 on:
   schedule:
@@ -78,7 +78,7 @@ jobs:
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'Updates detected by urlwatch',
+              title: 'New official releases published',
               body: body,
               labels: ['upstream', 'update']  # Add labels
             });

--- a/.github/workflows/urlwatch.yml
+++ b/.github/workflows/urlwatch.yml
@@ -2,7 +2,7 @@ name: Monitor Upstream Releases
 
 on:
   schedule:
-    - cron: '10 4 * * *'  # Daily at 4:10am
+    - cron: '10 10 * * *'  # Daily at 4:10am
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow named Monitor Upstream Releases. Scheduled to run daily, the workflow leverages urlwatch to monitor specified upstream URLs for new official releases. When changes are detected, it automatically creates a GitHub Issue with the relevant details, ensuring that the team is promptly informed about updates. 