### PR TITLE
feat: flake overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,9 @@
       systems = [
         "x86_64-linux"
       ];
+      imports = [
+        inputs.flake-parts.flakeModules.easyOverlay
+      ];
       perSystem = {
         config,
         system,
@@ -116,6 +119,9 @@
 
       in {
         formatter = pkgs.alejandra;
+        overlayAttrs = {
+          inherit (config.packages) autofirma; # configuradorfnmt dnieremote are specific to x86_64-linux
+        };
         devShells.default = let
           update-fixed-output-derivations = pkgs.callPackage ./nix/tools/update-fixed-output-derivations {};
           download-autofirma-trusted-providers = pkgs.callPackage ./nix/tools/download-autofirma-trusted-providers {};
@@ -215,6 +221,9 @@
             hm-standalone-dnieremote-config-jumpintro-usb = pkgs.callPackage ./nix/tests/hm-standalone/dnieremote/config/jumpintro-usb.nix { inherit self home-manager; };
             hm-standalone-dnieremote-config-jumpintro-no = pkgs.callPackage ./nix/tests/hm-standalone/dnieremote/config/jumpintro-no.nix { inherit self home-manager; };
             hm-standalone-dnieremote-config-wifiport = pkgs.callPackage ./nix/tests/hm-standalone/dnieremote/config/wifiport.nix { inherit self home-manager; };
+
+            # Overlay
+            overlay = pkgs.callPackage ./nix/tests/overlay { inherit self; };
 
         };
       in

--- a/nix/tests/overlay/default.nix
+++ b/nix/tests/overlay/default.nix
@@ -1,0 +1,32 @@
+{ self, pkgs, lib }:
+let
+  openssl = lib.getExe pkgs.openssl;
+in
+
+pkgs.nixosTest {
+  name = "test-overlay";
+  nodes.machine = { config, pkgs, modulesPath, ... }: let
+    pkgs' = pkgs.extend  self.overlays.default;
+  in {
+    imports = [
+      (modulesPath + "./../tests/common/x11.nix")
+      ../_common/nixos/stateVersion.nix
+    ];
+
+    environment.systemPackages = with pkgs'; [
+      autofirma
+    ];
+
+  };
+
+  testScript = ''
+    machine.succeed('echo "NixOS AutoFirma Sign Test" > document.txt')
+    machine.succeed('${openssl} req -x509 -newkey rsa:2048 -keyout private.key -out certificate.crt -days 365 -nodes -subj "/C=ES/O=TEST AUTOFIRMA NIX/OU=DNIE/CN=AC DNIE 004" -passout pass:1234')
+    machine.succeed('${openssl} pkcs12 -export -out certificate.p12 -inkey private.key -in certificate.crt -name "testcert" -password pass:1234')
+
+    machine.wait_for_x()
+
+    machine.succeed('autofirma sign -store pkcs12:certificate.p12 -i document.txt -o document.txt.sign -filter alias.contains=testcert -password 1234 -xml')
+  '';
+}
+


### PR DESCRIPTION
Adds an overlay so users of Nix package manager can make use of AutoFirma without needing NixOS/HM.