### PR TITLE
test: unit test autofirma-truststore. Closes #110

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -151,18 +151,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1740872140,
-        "narHash": "sha256-3wHafybyRfpUCLoE8M+uPVZinImg3xX+Nm6gEfN3G8I=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1740695751,
@@ -186,6 +174,7 @@
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
         "jmulticard-src": "jmulticard-src",
+        "nix-unit": "nix-unit",
         "nixpkgs": "nixpkgs_2"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -36,7 +36,9 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1740872218,
@@ -84,6 +86,52 @@
         "owner": "ctt-gob-es",
         "ref": "v1.8",
         "repo": "jmulticard",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-unit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731952509,
+        "narHash": "sha256-p4gB3Rhw8R6Ak4eMl8pqjCPOLCZRqaehZxdZ/mbFClM=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "7b5f051df789b6b20d259924d349a9ba3319b226",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix-unit": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1733705700,
+        "narHash": "sha256-stdx1z86yj66bChYswqjRw8BpdJRwxkH2XIJrsygpiM=",
+        "owner": "nix-community",
+        "repo": "nix-unit",
+        "rev": "d867d72d21da3b7d83f0feef73b0ac7f72b16437",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-unit",
         "type": "github"
       }
     },
@@ -139,6 +187,27 @@
         "home-manager": "home-manager",
         "jmulticard-src": "jmulticard-src",
         "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-unit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733662930,
+        "narHash": "sha256-9qOp6jNdezzLMxwwXaXZWPXosHbNqno+f7Ii/xftqZ8=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "357cda84af1d74626afb7fb3bc12d6957167cda9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -132,6 +132,9 @@
       }: let
         pkgs = nixpkgs.legacyPackages.${system};
       in {
+        nix-unit.inputs = {
+          inherit (inputs) nixpkgs flake-parts nix-unit;
+        };
         formatter = pkgs.alejandra;
         overlayAttrs = {
           inherit (config.packages) autofirma; # configuradorfnmt dnieremote are specific to x86_64-linux

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     home-manager.url = "github:nix-community/home-manager";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+    nix-unit.url = "github:nix-community/nix-unit";
+    nix-unit.inputs.nixpkgs.follows = "nixpkgs";
+    nix-unit.inputs.flake-parts.follows = "flake-parts";
   };
 
   # Autofirma sources
@@ -43,6 +47,7 @@
     jmulticard-src,
     clienteafirma-external-src,
     autofirma-src,
+    nix-unit
   }:
     flake-parts.lib.mkFlake {inherit inputs;} {
       flake = {
@@ -79,6 +84,7 @@
           dnieremote = pkgs.callPackage ./nix/dnieremote/default.nix {openssl_1_1 = ignoreVulnerable_openssl_1_1;};
           configuradorfnmt = pkgs.callPackage ./nix/configuradorfnmt/default.nix {};
         };
+        tests = import ./nix/tests/unit { inherit self; }; 
         checks.x86_64-linux = let
           pkgs = nixpkgs.legacyPackages.x86_64-linux;
         in {
@@ -115,6 +121,7 @@
       ];
       imports = [
         inputs.flake-parts.flakeModules.easyOverlay
+        inputs.nix-unit.modules.flake.default
       ];
       perSystem = {
         config,
@@ -140,6 +147,7 @@
             update-fixed-output-derivations
             download-autofirma-trusted-providers
             download-url-linked-CAs
+            nix-unit.packages.${system}.default
           ];
         };
         packages = let

--- a/nix/tests/unit/default.nix
+++ b/nix/tests/unit/default.nix
@@ -1,0 +1,29 @@
+{ self }:
+with builtins;
+let
+  ascendingOrder = sort lessThan;
+  truststorePath = "${self}/nix/autofirma/truststore";
+  providers = fromJSON (readFile "${truststorePath}/prestadores/providers.json");
+  allCAFiles = attrNames (readDir "${truststorePath}/prestadores/CAs-by-provider");
+  CAFetchLinks = fromJSON (readFile "${truststorePath}/prestadores/CAs_fetch_links.json");
+in
+{
+  testProviderListIsNotEmpty = {
+    expr = length providers > 0;
+    expected = true;
+  };
+  testCAFilesAndTrustedProvidersMatch = let
+    trimJsonExt = s: substring 0 ((stringLength s) - (stringLength ".json")) s;
+  in {
+    expr = ascendingOrder (map trimJsonExt allCAFiles);
+    expected = ascendingOrder (map (p: p.cif) providers);
+  };
+  testAllCAFilesHaveFetchLinkEntry = {
+    expr = ascendingOrder (map (p: p.cif) CAFetchLinks);
+    expected = ascendingOrder (map (p: p.cif) providers);
+  };
+  testAllFetchLinksHaveURLField = {
+    expr = all (link: hasAttr "url" link) CAFetchLinks;
+    expected = true;
+  };
+}


### PR DESCRIPTION
Here’s the list of tests:

- **`testProviderListIsNotEmpty`**: Ensures the list of trusted providers is not empty, as a truststore without providers is invalid.  
- **`testCAFilesAndTrustedProvidersMatch`**: Verifies that the list of CA files matches the list of trusted providers, ensuring every provider has an associated CA file and vice versa.  
- **`testAllCAFilesHaveFetchLinkEntry`**: Checks that each trusted provider has an entry in the fetch links list, ensuring CA files can be kept up to date.  
- **`testAllFetchLinksHaveURLField`**: Ensures every entry in the fetch links list contains a URL field, as fetch links without valid URLs would prevent CA updates.  