### PR TITLE
docs: improve documentation structure and introduce templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,271 +1,37 @@
-> **⚠️ Important Notice: Cache Configuration Update**
->
-> We recently migrated the `autofirma-nix` repository from one of the creators' accounts to the Nix Community's organization.  
-> As part of this migration, the binary cache has also changed. To avoid unnecessary compilations in your local machine, please update your `flake.nix` configuration to use the new cache. Replace the `nixConfig` section in your `flake.nix` file with the following:
->
-> ```nix
-> nixConfig = {
->   extra-substituters = [
->     "https://nix-community.cachix.org"
->   ];
->   extra-trusted-public-keys = [
->     "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
->   ];
-> };
-> ```
->
-> The old cache has been be removed, so making this change promptly will ensure a seamless experience.
-
-
 # autofirma-nix
 
-This repository provides a suite of tools needed to interact with Spain’s public administration,
-alongside NixOS and Home Manager modules for easy integration. These tools include:
+[![built with nix](https://builtwithnix.org/badge.svg)](https://builtwithnix.org)
 
-- **AutoFirma** for digitally signing documents  
-- **DNIeRemote** for using an NFC-based national ID with an Android device as an NFC reader  
-- **Configurador FNMT-RCM** for securely requesting the personal certificate from the Spanish Royal Mint (**Fábrica Nacional de Moneda y Timbre**)  
+Nix packages, NixOS modules, and Home Manager modules for the suite of tools required to interact with Spain's public administration digital services:
 
-## Usage Example
+- **AutoFirma** - Digital document signing and web authentication
+- **DNIeRemote** - Use your smartphone as an NFC reader for your Spanish national ID card
+- **Configurador FNMT-RCM** - Request and install certificates from the Spanish Royal Mint
 
-```console
-$ nix run --accept-flake-config github:nix-community/autofirma-nix#dnieremote
+## Quick Start
+
+```bash
+# Run DNIeRemote directly
+nix run github:nix-community/autofirma-nix#dnieremote
+
+# Create a new NixOS configuration with AutoFirma
+nix flake new --template github:nix-community/autofirma-nix#nixos-module ./my-autofirma-system
+
+# Create a new Home Manager configuration with AutoFirma
+nix flake new --template github:nix-community/autofirma-nix#home-manager-standalone ./my-autofirma-home
 ```
 
-## AutoFirma on NixOS and Home Manager
+## Documentation
 
-A NixOS module is provided to enable AutoFirma on NixOS and another one for Home Manager.
-You only need to enable one of them, depending on whether you want AutoFirma
-system-wide or at the user level.
+Comprehensive documentation is available at:
+https://nix-community.github.io/autofirma-nix/
 
-### Home Manager Configuration
+There you'll find:
+- Detailed installation instructions for NixOS and Home Manager
+- Configuration options reference
+- Security considerations
+- Troubleshooting guide
 
-The integration of AutoFirma in Home Manager enables the `autofirma` command for
-signing PDF documents and configures the Firefox browser (if enabled through
-`programs.firefox.enable`) to use AutoFirma on websites that require it.
+## License
 
-Additionally, you can enable DNIe integration, including NFC-based DNIe from an
-Android mobile via DNIeRemote.
-
-`autofirma-nix` provides a Home Manager module that you should import in your Home
-Manager configuration file. The setup may vary slightly depending on your Home
-Manager installation method. Below are examples for a standalone configuration.
-
-```nix
-# flake.nix
-
-{
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-
-    home-manager = {
-      url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    autofirma-nix = {
-      url = "github:nix-community/autofirma-nix";  # If you're tracking NixOS unstable
-      # url = "github:nix-community/autofirma-nix/release-24.11";  # If you're tracking NixOS 24.11
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-  };
-
-  nixConfig = {
-    extra-substituters = [
-      "https://nix-community.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-    ];
-  };
-
-  outputs = {nixpkgs, home-manager, autofirma-nix, ...}: {
-    homeConfigurations."miusuario" = home-manager.lib.homeManagerConfiguration {
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-
-      modules = [
-        autofirma-nix.homeManagerModules.default
-        ./home.nix
-      ];
-    };
-  };
-}
-```
-
-```nix
-# home.nix
-{ pkgs, config, ... }: {
-  config = {
-    programs.autofirma.enable = true;
-    programs.autofirma.firefoxIntegration.profiles = {
-      myprofile = {  # The name of the Firefox profile where AutoFirma will be enabled
-        enable = true;
-      };
-    };
-    programs.dnieremote.enable = true;
-
-    programs.configuradorfnmt.enable = true;
-    programs.configuradorfnmt.firefoxIntegration.profiles = {
-      myprofile = {  # The name of the Firefox profile where the FNMT Configurator will be enabled
-        enable = true;
-      };
-    };
-
-    programs.firefox = {
-      enable = true;
-      policies = {
-        SecurityDevices = {
-          "OpenSC PKCS11" = "${pkgs.opensc}/lib/opensc-pkcs11.so";  # To use DNIe and other smart cards
-          "DNIeRemote" = "${config.programs.dnieremote.finalPackage}/lib/libdnieremotepkcs11.so";  # To use DNIe via NFC from an Android mobile
-        };
-      };
-      profiles.myprofile = {
-        id = 0;  # Makes this profile the default profile
-        # ... Other configuration options for this profile
-      };
-    };
-  };
-}
-```
-
-### NixOS Configuration
-
-The AutoFirma integration in NixOS enables the `autofirma` command for signing PDF
-documents and configures the Firefox browser (if enabled through
-`programs.firefox.enable`) to use AutoFirma on websites that require it.
-
-Additionally, you can enable DNIe integration, including NFC-based DNIe from an
-Android mobile via DNIeRemote.
-
-```nix
-# flake.nix
-
-{
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    autofirma-nix.url = "github:nix-community/autofirma-nix";
-    # autofirma-nix.url = "github:nix-community/autofirma-nix/release-24.11";  # If you're using NixOS 24.11
-  };
-
-  outputs = { self, nixpkgs, autofirma-nix, ... }: {
-    nixosConfigurations."hostname" = nixpkgs.lib.nixosSystem {
-      system = "x86_64-linux";
-      modules = [
-        autofirma-nix.nixosModules.default
-        ({ pkgs, config, ... }: {
-          programs.autofirma.enable = true;
-          programs.autofirma.firefoxIntegration.enable = true;  # Let Firefox use AutoFirma
-
-          programs.dnieremote.enable = true;
-
-          programs.configuradorfnmt.enable = true;
-          programs.configuradorfnmt.firefoxIntegration.enable = true;  # Let Firefox use the FNMT Configurator
-
-          # Firefox
-          programs.firefox.enable = true;
-          programs.firefox.policies = {
-            SecurityDevices = {
-              "OpenSC PKCS#11" = "${pkgs.opensc}/lib/opensc-pkcs11.so";  # To use DNIe and other smart cards
-              "DNIeRemote" = "${config.programs.dnieremote.finalPackage}/lib/libdnieremotepkcs11.so";  # To use DNIe via NFC from an Android mobile
-            };
-          };
-        })
-      ];
-    };
-  };
-}
-```
-
-## Managing Certificates in **autofirma-nix**
-
-The Government publishes a list of authorized service providers, each offering various
-certificates (production, development, valid, expired, etc.). For **autofirma-nix** to
-trust a specific certificate, two conditions must be met:
-
-1. It must come from one of these official providers.
-2. It must also appear in the system’s *ca-bundle* (or *cacerts*) on NixOS.
-
-This way, **autofirma-nix** only accepts certificates recognized by both the Government
-and the system. If the user blocks or adds one in the NixOS configuration, those changes
-are automatically applied to **autofirma-nix**. If a certificate is not in the local
-*ca-bundle*, even if an official provider publishes it, **autofirma-nix** will not include
-it.
-
-### Relevant NixOS Options
-
-The following NixOS options determine which certificates are accepted or blocked in the
-system *truststore*, directly affecting **autofirma-nix**:
-
-- **`security.pki.certificateFiles`**  
-  Adds additional certificates to the global *truststore*. If any match the official list,
-  **autofirma-nix** will accept them.
-
-- **`security.pki.caCertificateBlacklist`**  
-  Blocks specific certificates. Even if they are on the official list, **autofirma-nix** will
-  exclude them if they appear in this blacklist.
-
-**Minimal Example**:
-```nix
-{
-  security.pki = {
-    certificateFiles = [
-      ./my-certificate.crt
-    ];
-    caCertificateBlacklist = [
-      "Izenpe.com"
-    ];
-  };
-  programs.autofirma.enable = true;
-}
-```
-
-If `./my-certificate.crt` is on the official list, it will be included in autofirma-nix.
-However, since `Izenpe.com` is blocked, it will be ignored even if it appears on the
-official list.
-
-## Troubleshooting
-
-### Security devices do not seem to update or do not appear
-
-If you have installed AutoFirma and enabled Firefox integration, but Firefox does not
-detect the security devices, you may need to remove the `pkcs11.txt` file from the
-Firefox profile folder. For instance, if you enabled the Home Manager module and the
-profile is named `myprofile`, the file is located in `~/.mozilla/firefox/myprofile/pkcs11.txt`.
-
-Removing it and restarting Firefox should solve the issue:
-
-```console
-$ rm ~/.mozilla/firefox/myprofile/pkcs11.txt
-$ firefox
-```
-
-### Missing certificates even though the DNIe PIN was requested
-
-If OpenSC PKCS#11 prompts you for a password but no certificates are available for
-signing, you might see something like the following in the Autofirma logs (when
-running it from a terminal):
-
-```console
-$ autofirma
-...
-INFO: El almacen externo 'OpenSC PKCS#11' ha podido inicializarse, se anadiran sus entradas y se detiene la carga del resto de almacenes
-...
-INFO: Se ocultara el certificado por no estar vigente: java.security.cert.CertificateExpiredException: NotAfter: Sat Oct 26 15:03:27 GMT 2024
-...
-INFO: Se ocultara el certificado por no estar vigente: java.security.cert.CertificateExpiredException: NotAfter: Sat Oct 26 15:03:27 GMT 2024
-...
-SEVERE: Se genero un error en el dialogo de seleccion de certificados: java.lang.reflect.InvocationTargetException
-....
-SEVERE: El almacen no contiene ningun certificado que se pueda usar para firmar: es.gob.afirma.keystores.AOCertificatesNotFoundException: No se han encontrado certificados validos en el almacen
-```
-
-This occurs because your certificates have expired, as indicated by the “NotAfter:” date.
-
-If the certificates are not expired because you recently renewed them, but you used
-AutoFirma before this renewal, it is possible that OpenSC has cached your old certificates.
-To fix this, you need to delete the OpenSC cache. [By default, it is located at
-$HOME/.cache/opensc](https://github.com/OpenSC/OpenSC/wiki/Environment-variables).
-
-```console
-$ rm -rf $HOME/.cache/opensc
-```
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,7 +4,8 @@
 
 - [Installation](./installation.md)
   - [NixOS module](./installation_nixos_module.md)
-  - [Home Manager module](./installation_home_manager_module.md)
+  - [Home Manager with NixOS](./installation_home_manager_module.md)
+  - [Home Manager standalone](./installation_home_manager_standalone.md)
 - [Security](./security.md)
 - [Troubleshooting](./troubleshooting.md)
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,22 +1,25 @@
 # Installation
 
-This project is distributed as a Nix flake for easy integration into your NixOS configuration. It provides both a NixOS module for system-wide configurations and a Home Manager module for user-specific setups. Depending on your preference, you can choose one or the other.
+This project is distributed as a Nix flake that supports three integration paths:
 
-Keep in mind that you should enable either the NixOS module or the Home Manager module—not both simultaneously. Think of it like wearing one hat at a time.
+1. **NixOS module** - For system-wide installation
+2. **Home Manager module with NixOS** - For per-user installation when Home Manager is used as a NixOS module
+3. **Home Manager standalone** - For per-user installation with standalone Home Manager
 
-Depending on your Nix channel:
+## Flake Input Setup
 
-- Use the main branch with `nixpkgs-unstable`.
-- For stable channels, use the `release-XX.YY` branch corresponding to your NixOS version.
-
-We officially support current releases. If you encounter issues on an older branch, upgrading is recommended, as it might resolve the problem—and let’s face it, newer is usually better.
-
-Here’s an example configuration to include `autofirma-nix` as an input:
+For all installation methods, you'll need to add autofirma-nix to your flake inputs:
 
 ```nix
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    
+    # Only needed for Home Manager options
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     autofirma-nix = {
       url = "github:nix-community/autofirma-nix";  # For nixpkgs-unstable
@@ -33,7 +36,7 @@ Here’s an example configuration to include `autofirma-nix` as an input:
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
     ];
   };
-
-  # Further configuration details are provided in the sections below.
 }
 ```
+
+The binary cache configuration is strongly recommended to avoid unnecessary local compilation.

--- a/docs/src/installation_home_manager_module.md
+++ b/docs/src/installation_home_manager_module.md
@@ -1,49 +1,95 @@
-# Home Manager module
+# Home Manager with NixOS
 
-If you prefer per-user flexibility and customization, the **autofirma-nix** Home Manager module is the way to go. Here’s how you can set it up in your Home Manager configuration:
+If you're using Home Manager as a NixOS module and want a per-user AutoFirma setup, this approach provides fine-grained configuration for each user.
+
+## Quick Start with Template
+
+You can quickly get started with a fully configured template:
+
+```bash
+$ nix flake new --template github:nix-community/autofirma-nix#home-manager-nixos ./my-autofirma-system-with-hm
+```
+
+This creates a new directory with a complete flake configuration for Home Manager as a NixOS module with all available options.
+
+## Minimal Configuration
+
+First, make sure Home Manager is imported in your NixOS configuration:
 
 ```nix
 {
-  outputs = { self, home-manager, autofirma-nix, nixpkgs, ... }:
-    {
-      homeConfigurations."my-user" = home-manager.lib.homeManagerConfiguration {
-        pkgs = nixpkgs.legacyPackages.x86_64-linux;
+  imports = [
+    # Your other imports
+    home-manager.nixosModules.home-manager
+  ];
 
-        modules = [
-          autofirma-nix.homeManagerModules.default
+  home-manager.useGlobalPkgs = true;
+  home-manager.useUserPackages = true;
+}
+```
 
-          {
-            programs.autofirma.enable = true;
-            programs.autofirma.firefoxIntegration.profiles = {
-              myprofile = {
-                enable = true;
-              };
-            };
+Then, configure AutoFirma for a specific user:
 
-            programs.dnieremote.enable = true;
-
-            programs.configuradorfnmt.enable = true;
-            programs.configuradorfnmt.firefoxIntegration.profiles = {
-              myprofile = {
-                enable = true;
-              };
-            };
-
-            programs.firefox = {
-              enable = true;
-              policies = {
-                SecurityDevices = {
-                  "OpenSC PKCS11" = "${pkgs.opensc}/lib/opensc-pkcs11.so";
-                  "DNIeRemote" = "${config.programs.dnieremote.finalPackage}/lib/libdnieremotepkcs11.so";
-                };
-              };
-              profiles.myprofile = {
-                id = 0;
-              };
-            };
-          }
-        ];
+```nix
+{
+  home-manager.users.yourUsername = { config, pkgs, ... }: {
+    imports = [
+      autofirma-nix.homeManagerModules.default
+    ];
+    
+    # Basic AutoFirma setup
+    programs.autofirma.enable = true;
+    
+    # Firefox integration with specific profile(s)
+    programs.autofirma.firefoxIntegration.profiles = {
+      default = { # Use your actual profile name
+        enable = true;
       };
     };
+    
+    # Optional: DNIe support via smartphone NFC
+    programs.dnieremote.enable = true;
+    
+    # Optional: FNMT certificate configurator
+    programs.configuradorfnmt.enable = true;
+    programs.configuradorfnmt.firefoxIntegration.profiles = {
+      default = { # Use your actual profile name
+        enable = true;
+      };
+    };
+    
+    # If Firefox is managed by Home Manager
+    programs.firefox = {
+      enable = true;
+      policies = {
+        SecurityDevices = {
+          # For physical smart card readers
+          "OpenSC PKCS11" = "${pkgs.opensc}/lib/opensc-pkcs11.so";
+          # For smartphone NFC
+          "DNIeRemote" = "${config.programs.dnieremote.finalPackage}/lib/libdnieremotepkcs11.so";
+        };
+      };
+      profiles.default = { # Use your actual profile name
+        id = 0; # Makes this profile the default profile
+      };
+    };
+  };
 }
+```
+
+## What This Does
+
+With this configuration:
+
+1. AutoFirma is only available to the specified user(s)
+2. Firefox integration is limited to specific Firefox profiles
+3. Each user can have their own customized setup
+4. Only users who need these tools will have them installed
+
+## Rebuild and Apply
+
+After adding these changes, rebuild your NixOS configuration:
+
+```bash
+sudo nixos-rebuild switch --flake .#yourHostname
 ```

--- a/docs/src/installation_home_manager_standalone.md
+++ b/docs/src/installation_home_manager_standalone.md
@@ -1,0 +1,88 @@
+# Home Manager Standalone
+
+If you're using Home Manager in standalone mode (not integrated with NixOS configuration), this approach lets you manage AutoFirma through your personal configuration.
+
+## Quick Start with Template
+
+You can quickly get started with a fully configured template:
+
+```bash
+$ nix flake new --template github:nix-community/autofirma-nix#home-manager-standalone ./my-autofirma-home
+```
+
+This creates a new directory with a complete flake configuration for standalone Home Manager with all available options.
+
+## Minimal Configuration
+
+In your `flake.nix` for Home Manager:
+
+```nix
+{
+  outputs = { self, nixpkgs, home-manager, autofirma-nix, ... }: {
+    homeConfigurations."yourUsername" = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux; # Adjust system if needed
+      
+      modules = [
+        autofirma-nix.homeManagerModules.default
+        
+        # Your home configuration
+        {
+          # Basic AutoFirma setup
+          programs.autofirma.enable = true;
+          
+          # Firefox integration with specific profile(s)
+          programs.autofirma.firefoxIntegration.profiles = {
+            default = { # Use your actual profile name
+              enable = true;
+            };
+          };
+          
+          # Optional: DNIe support via smartphone NFC
+          programs.dnieremote.enable = true;
+          
+          # Optional: FNMT certificate configurator
+          programs.configuradorfnmt.enable = true;
+          programs.configuradorfnmt.firefoxIntegration.profiles = {
+            default = { # Use your actual profile name
+              enable = true;
+            };
+          };
+          
+          # If Firefox is managed by Home Manager
+          programs.firefox = {
+            enable = true;
+            policies = {
+              SecurityDevices = {
+                # For physical smart card readers
+                "OpenSC PKCS11" = "${pkgs.opensc}/lib/opensc-pkcs11.so";
+                # For smartphone NFC
+                "DNIeRemote" = "${config.programs.dnieremote.finalPackage}/lib/libdnieremotepkcs11.so";
+              };
+            };
+            profiles.default = { # Use your actual profile name
+              id = 0; # Makes this profile the default profile
+            };
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+## What This Does
+
+This configuration:
+
+1. Adds AutoFirma to your personal Home Manager setup
+2. Configures Firefox integration for your specific profile(s)
+3. Provides a complete environment for working with Spanish digital signatures
+4. Preserves the flexibility of Home Manager's standalone mode
+
+## Apply the Configuration
+
+After adding these changes, apply your Home Manager configuration:
+
+```bash
+home-manager switch --flake .#yourUsername
+```

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,21 @@
             ];
           };
         };
+        templates = {
+          nixos-module = {
+            path = ./templates/nixos-module;
+            description = "NixOS system with AutoFirma (system-wide installation)";
+          };
+          home-manager-nixos = {
+            path = ./templates/home-manager-nixos;
+            description = "Home Manager with NixOS for AutoFirma (user-specific installation)";
+          };
+          home-manager-standalone = {
+            path = ./templates/home-manager-standalone;
+            description = "Home Manager Standalone for AutoFirma (user-specific installation without NixOS)";
+          };
+          default = self.templates.nixos-module;
+        };
         packages.x86_64-linux = let
           pkgs = nixpkgs.legacyPackages.x86_64-linux;
           ignoreVulnerable_openssl_1_1 = pkgs.openssl_1_1.overrideAttrs (oldAttrs: rec {

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,21 @@
+# AutoFirma-Nix Templates
+
+This directory contains flake templates for the three supported installation methods of autofirma-nix.
+
+## Available Templates
+
+1. **nixos-module** - System-wide installation for NixOS
+2. **home-manager-nixos** - Per-user installation with Home Manager as a NixOS module
+3. **home-manager-standalone** - Per-user installation with standalone Home Manager
+
+Each template can be used by running:
+
+```bash
+nix flake new --template github:nix-community/autofirma-nix#template-name ./destination-directory
+```
+
+For example:
+
+```bash
+nix flake new --template github:nix-community/autofirma-nix#nixos-module ./my-autofirma-system
+```

--- a/templates/home-manager-nixos/flake.nix
+++ b/templates/home-manager-nixos/flake.nix
@@ -158,14 +158,6 @@
             };
           };
 
-          # Additional useful packages for smart card support
-          environment.systemPackages = with pkgs; [
-            opensc
-            pcsc-lite
-            pcsc-tools
-            ccid
-          ];
-
           # Enable PC/SC smart card service
           services.pcscd.enable = true;
         })

--- a/templates/home-manager-nixos/flake.nix
+++ b/templates/home-manager-nixos/flake.nix
@@ -1,0 +1,175 @@
+{
+  description = "Home Manager with NixOS for AutoFirma (user-specific installation)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    
+    autofirma-nix = {
+      url = "github:nix-community/autofirma-nix";
+      # For stable release: url = "github:nix-community/autofirma-nix/release-24.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+  };
+
+  outputs = { self, nixpkgs, home-manager, autofirma-nix, ... }: {
+    nixosConfigurations.mysystem = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      
+      modules = [
+        home-manager.nixosModules.home-manager
+        
+        ({ config, pkgs, ... }: {
+          # Basic system configuration
+          networking.hostName = "mysystem";
+          time.timeZone = "Europe/Madrid";
+          system.stateVersion = "23.11";
+
+          # Home Manager configuration
+          home-manager.useGlobalPkgs = true;
+          home-manager.useUserPackages = true;
+          
+          # User account setup
+          users.users.myuser = {
+            isNormalUser = true;
+            extraGroups = [ "wheel" "networkmanager" ];
+            home = "/home/myuser";
+          };
+          
+          # Configure Home Manager for the user
+          home-manager.users.myuser = { config, ... }: {
+            imports = [
+              autofirma-nix.homeManagerModules.default
+            ];
+            
+            home.stateVersion = "23.11";
+            
+            # ===============================
+            # === AutoFirma Configuration ===
+            # ===============================
+            programs.autofirma = {
+              # Enable AutoFirma
+              enable = true;
+              
+              # Firefox integration with specific profile(s)
+              firefoxIntegration.profiles = {
+                default = {
+                  enable = true;
+                };
+              };
+              
+              # Custom package (uncomment if needed)
+              # package = pkgs.autofirma;
+              
+              # Custom truststore package (uncomment if needed)
+              # truststore.package = pkgs.autofirma-truststore;
+              
+              # AutoFirma config options
+              config = {
+                # Avoid confirmation dialog when closing
+                omitAskOnClose = true;
+                
+                # Enable JMultiCard functionality
+                enabledJmulticard = true;
+                
+                # Allow invalid signatures
+                allowInvalidSignatures = false;
+                
+                # Use implicit mode for CAdES signatures
+                cadesImplicitMode = true;
+                
+                # More config options available - see home_manager_options.html
+              };
+            };
+
+            # ===============================
+            # === DNIeRemote Configuration ===
+            # ===============================
+            programs.dnieremote = {
+              # Enable DNIeRemote for using smartphone as DNIe reader
+              enable = true;
+              
+              # Skip intro screen and go directly to USB or WiFi setup
+              # Possible values: "no" (default), "usb", "wifi"
+              jumpIntro = "no";
+              
+              # Port for WiFi connection to smartphone
+              wifiPort = 9501;
+              
+              # Port for USB connection to smartphone
+              usbPort = 9501;
+              
+              # Custom package (uncomment if needed)
+              # package = pkgs.dnieremote;
+            };
+
+            # =======================================
+            # === FNMT Configurator Configuration ===
+            # =======================================
+            programs.configuradorfnmt = {
+              # Enable FNMT certificate configuration tool
+              enable = true;
+              
+              # Firefox integration with specific profile(s)
+              firefoxIntegration.profiles = {
+                default = {
+                  enable = true;
+                };
+              };
+              
+              # Custom package (uncomment if needed)
+              # package = pkgs.configuradorfnmt;
+            };
+
+            # =============================
+            # === Firefox Configuration ===
+            # =============================
+            programs.firefox = {
+              enable = true;
+              
+              # Set up security devices for DNIe access
+              policies = {
+                SecurityDevices = {
+                  # For physical smart card readers (like DNIe)
+                  "OpenSC PKCS11" = "${pkgs.opensc}/lib/opensc-pkcs11.so";
+                  
+                  # For smartphone NFC using DNIeRemote
+                  "DNIeRemote" = "${config.programs.dnieremote.finalPackage}/lib/libdnieremotepkcs11.so";
+                };
+              };
+              
+              # Define Firefox profiles 
+              profiles.default = {
+                id = 0; # Makes this the default profile
+              };
+            };
+          };
+
+          # Additional useful packages for smart card support
+          environment.systemPackages = with pkgs; [
+            opensc
+            pcsc-lite
+            pcsc-tools
+            ccid
+          ];
+
+          # Enable PC/SC smart card service
+          services.pcscd.enable = true;
+        })
+      ];
+    };
+  };
+}

--- a/templates/home-manager-standalone/flake.nix
+++ b/templates/home-manager-standalone/flake.nix
@@ -1,0 +1,153 @@
+{
+  description = "Home Manager Standalone for AutoFirma (user-specific installation without NixOS)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    
+    autofirma-nix = {
+      url = "github:nix-community/autofirma-nix";
+      # For stable release: url = "github:nix-community/autofirma-nix/release-24.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+  };
+
+  outputs = { self, nixpkgs, home-manager, autofirma-nix, ... }: {
+    homeConfigurations."myuser" = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      
+      modules = [
+        autofirma-nix.homeManagerModules.default
+        
+        {
+          home = {
+            username = "myuser";
+            homeDirectory = "/home/myuser";
+            stateVersion = "23.11";
+          };
+          
+          # ===============================
+          # === AutoFirma Configuration ===
+          # ===============================
+          programs.autofirma = {
+            # Enable AutoFirma
+            enable = true;
+            
+            # Firefox integration with specific profile(s)
+            firefoxIntegration.profiles = {
+              default = {
+                enable = true;
+              };
+            };
+            
+            # Custom package (uncomment if needed)
+            # package = pkgs.autofirma;
+            
+            # Custom truststore package (uncomment if needed)
+            # truststore.package = pkgs.autofirma-truststore;
+            
+            # AutoFirma config options
+            config = {
+              # Avoid confirmation dialog when closing
+              omitAskOnClose = true;
+              
+              # Enable JMultiCard functionality
+              enabledJmulticard = true;
+              
+              # Allow invalid signatures
+              allowInvalidSignatures = false;
+              
+              # Use implicit mode for CAdES signatures
+              cadesImplicitMode = true;
+              
+              # More config options available - see home_manager_options.html
+            };
+          };
+
+          # ===============================
+          # === DNIeRemote Configuration ===
+          # ===============================
+          programs.dnieremote = {
+            # Enable DNIeRemote for using smartphone as DNIe reader
+            enable = true;
+            
+            # Skip intro screen and go directly to USB or WiFi setup
+            # Possible values: "no" (default), "usb", "wifi"
+            jumpIntro = "no";
+            
+            # Port for WiFi connection to smartphone
+            wifiPort = 9501;
+            
+            # Port for USB connection to smartphone
+            usbPort = 9501;
+            
+            # Custom package (uncomment if needed)
+            # package = pkgs.dnieremote;
+          };
+
+          # =======================================
+          # === FNMT Configurator Configuration ===
+          # =======================================
+          programs.configuradorfnmt = {
+            # Enable FNMT certificate configuration tool
+            enable = true;
+            
+            # Firefox integration with specific profile(s)
+            firefoxIntegration.profiles = {
+              default = {
+                enable = true;
+              };
+            };
+            
+            # Custom package (uncomment if needed)
+            # package = pkgs.configuradorfnmt;
+          };
+
+          # =============================
+          # === Firefox Configuration ===
+          # =============================
+          programs.firefox = {
+            enable = true;
+            
+            # Set up security devices for DNIe access
+            policies = {
+              SecurityDevices = {
+                # For physical smart card readers (like DNIe)
+                "OpenSC PKCS11" = "${pkgs.opensc}/lib/opensc-pkcs11.so";
+                
+                # For smartphone NFC using DNIeRemote
+                "DNIeRemote" = "${config.programs.dnieremote.finalPackage}/lib/libdnieremotepkcs11.so";
+              };
+            };
+            
+            # Define Firefox profiles 
+            profiles.default = {
+              id = 0; # Makes this the default profile
+            };
+          };
+          
+          # Make sure pcsc-lite is available for smart card support
+          home.packages = with pkgs; [
+            opensc
+            pcsc-lite
+            pcsc-tools
+            ccid
+          ];
+        }
+      ];
+    };
+  };
+}

--- a/templates/home-manager-standalone/flake.nix
+++ b/templates/home-manager-standalone/flake.nix
@@ -25,8 +25,13 @@
     ];
   };
 
-  outputs = { self, nixpkgs, home-manager, autofirma-nix, ... }: {
+  outputs = { self, nixpkgs, home-manager, autofirma-nix, ... }: 
+  let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+  in {
     homeConfigurations."myuser" = home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
       
       modules = [
         autofirma-nix.homeManagerModules.default

--- a/templates/home-manager-standalone/flake.nix
+++ b/templates/home-manager-standalone/flake.nix
@@ -27,12 +27,11 @@
 
   outputs = { self, nixpkgs, home-manager, autofirma-nix, ... }: {
     homeConfigurations."myuser" = home-manager.lib.homeManagerConfiguration {
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
       
       modules = [
         autofirma-nix.homeManagerModules.default
         
-        {
+        ({pkgs, config, ... }: {
           home = {
             username = "myuser";
             homeDirectory = "/home/myuser";
@@ -139,14 +138,7 @@
             };
           };
           
-          # Make sure pcsc-lite is available for smart card support
-          home.packages = with pkgs; [
-            opensc
-            pcsc-lite
-            pcsc-tools
-            ccid
-          ];
-        }
+        })
       ];
     };
   };

--- a/templates/nixos-module/flake.nix
+++ b/templates/nixos-module/flake.nix
@@ -1,0 +1,131 @@
+{
+  description = "NixOS system with AutoFirma (system-wide installation)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    
+    autofirma-nix = {
+      url = "github:nix-community/autofirma-nix";
+      # For stable release: url = "github:nix-community/autofirma-nix/release-24.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+  };
+
+  outputs = { self, nixpkgs, autofirma-nix, ... }: {
+    nixosConfigurations.mysystem = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      
+      modules = [
+        autofirma-nix.nixosModules.default
+        
+        ({ config, pkgs, ... }: {
+          # Basic system configuration
+          networking.hostName = "mysystem";
+          time.timeZone = "Europe/Madrid";
+          system.stateVersion = "23.11";
+
+          users.users.myuser = {
+            isNormalUser = true;
+            extraGroups = [ "wheel" "networkmanager" ];
+          };
+
+          # ===============================
+          # === AutoFirma Configuration ===
+          # ===============================
+          programs.autofirma = {
+            # Enable AutoFirma
+            enable = true;
+            
+            # Enable Firefox integration
+            firefoxIntegration.enable = true;
+            
+            # Fix Java certificates (deprecated)
+            # fixJavaCerts = false;
+            
+            # Custom package (uncomment if needed)
+            # package = pkgs.autofirma;
+            
+            # Custom truststore package (uncomment if needed)
+            # truststore.package = pkgs.autofirma-truststore;
+          };
+
+          # =======================================
+          # === DNIeRemote Configuration ===
+          # =======================================
+          programs.dnieremote = {
+            # Enable DNIeRemote for using smartphone as DNIe reader
+            enable = true;
+            
+            # Skip intro screen and go directly to USB or WiFi setup
+            # Possible values: "no" (default), "usb", "wifi"
+            jumpIntro = "no";
+            
+            # Port for WiFi connection to smartphone
+            wifiPort = 9501;
+            
+            # Port for USB connection to smartphone
+            usbPort = 9501;
+            
+            # Whether to open the firewall for the WiFi port
+            openFirewall = false;
+            
+            # Custom package (uncomment if needed)
+            # package = pkgs.dnieremote;
+          };
+
+          # =======================================
+          # === FNMT Configurator Configuration ===
+          # =======================================
+          programs.configuradorfnmt = {
+            # Enable FNMT certificate configuration tool
+            enable = true;
+            
+            # Enable Firefox integration
+            firefoxIntegration.enable = true;
+            
+            # Custom package (uncomment if needed)
+            # package = pkgs.configuradorfnmt;
+          };
+
+          # =============================
+          # === Firefox Configuration ===
+          # =============================
+          programs.firefox = {
+            enable = true;
+            
+            # Set up security devices for DNIe access
+            policies = {
+              SecurityDevices = {
+                # For physical smart card readers (like DNIe)
+                "OpenSC PKCS#11" = "${pkgs.opensc}/lib/opensc-pkcs11.so";
+                
+                # For smartphone NFC using DNIeRemote
+                "DNIeRemote" = "${config.programs.dnieremote.finalPackage}/lib/libdnieremotepkcs11.so";
+              };
+            };
+          };
+
+          # Additional useful packages for smart card support
+          environment.systemPackages = with pkgs; [
+            opensc
+            pcsc-lite
+            pcsc-tools
+            ccid
+          ];
+
+          # Enable PC/SC smart card service
+          services.pcscd.enable = true;
+        })
+      ];
+    };
+  };
+}

--- a/templates/nixos-module/flake.nix
+++ b/templates/nixos-module/flake.nix
@@ -114,14 +114,6 @@
             };
           };
 
-          # Additional useful packages for smart card support
-          environment.systemPackages = with pkgs; [
-            opensc
-            pcsc-lite
-            pcsc-tools
-            ccid
-          ];
-
           # Enable PC/SC smart card service
           services.pcscd.enable = true;
         })


### PR DESCRIPTION
- Refactored README to minimize information that overlaps with the docs
- Fixed DocBook documentation issues
- Updated installation documentation to distinguish between NixOS and Home Manager setups
- Introduced new documentation pages:
  - `installation_home_manager_standalone.md` for standalone Home Manager users
- Added flake templates for quick setup:
  - `templates/nixos-module`
  - `templates/home-manager-nixos`
  - `templates/home-manager-standalone`
- Minor improvements to `flake.nix`