### PR TITLE
fix: rendering of html entities in extracted autofirma home-manager config options

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -44,4 +44,5 @@
   - any-glob-to-any-file:
     - docs/**/*                        # Documentation files
     - README.md
+    - nix/tools/properties-to-json/**/*
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ on:
       - 'docs/**'
       - 'nix/**/module.nix'
       - 'nix/**/hm-module.nix'
+      - 'nix/tools/properties-to-json/**'
 
 jobs:
   build:

--- a/fixed-output-derivations.lock
+++ b/fixed-output-derivations.lock
@@ -6,7 +6,7 @@
     "hash": "sha256-N2lFeRM/eu/tMFTCQRYSHYrbXNgbAv49S7qTaUmb2+Q="
   },
   "autofirma.clienteafirma": {
-    "hash": "sha256-3o2PpIQb+UxdqmSt8B9q/LRBmxodUa4ksK6W8fykOEE=",
+    "hash": "sha256-jaiDhXT346+0zWlD1J9xhwDpjQca9DSpBmNgF+VKaJs=",
     "dependencies": [
       "autofirma.clienteafirma.dependencies.jmulticard",
       "autofirma.clienteafirma.dependencies.clienteafirma-external"

--- a/nix/autofirma/default.nix
+++ b/nix/autofirma/default.nix
@@ -55,7 +55,7 @@
       javaVersion = "17";
       srcVersion = "${src.rev}-autofirma-nix";
       javadocVersion = "3.11.2";
-      xmlDocletVersion = "2.0.2";
+      xmlDocletVersion = "2.0.3";
     in
     ''
       # Update the version of the Java runtime to use

--- a/nix/tools/properties-to-json/default.nix
+++ b/nix/tools/properties-to-json/default.nix
@@ -1,2 +1,22 @@
-{ writers }:
-writers.writePython3Bin "properties-to-json" { } (builtins.readFile ./properties-to-json.py)
+{ stdenv, python3, pandoc, makeWrapper, lib }:
+
+stdenv.mkDerivation {
+  name = "properties-to-json";
+  dontUnpack = true;  # No archive to unpack (using a single script file)
+
+  # Dependencies
+  nativeBuildInputs = [ makeWrapper ];        # needed for makeWrapper utility
+  buildInputs = [ python3 pandoc ];           # python3 interpreter and pandoc at runtime
+
+  installPhase = ''
+    # Install the Python script to $out/bin and make it executable
+    install -Dm755 ${./properties-to-json.py} $out/bin/properties-to-json
+
+    # Patch the shebang to use the exact python3 path from Nix store
+    patchShebangs $out/bin
+
+    # Wrap the script to include pandoc in PATH at runtime
+    wrapProgram $out/bin/properties-to-json \
+      --prefix PATH : ${pandoc}/bin
+  '';
+}


### PR DESCRIPTION
This pull request includes several changes to the `nix` directory, primarily focusing on updating dependencies and enhancing the functionality of the `properties-to-json` tool. The most important changes are grouped into dependency updates and functionality enhancements.

### Dependency Updates:
* [`nix/autofirma/default.nix`](diffhunk://#diff-2ae8ce23b1a8b0964fc8abe3a47325b266710da736caf2ed5d647486abbd14a1L58-R58): Updated `xmlDocletVersion` from `2.0.2` to `2.0.3`.

### Functionality Enhancements:
* [`nix/tools/properties-to-json/default.nix`](diffhunk://#diff-336a85e34b71d711addea369944a787f2c88cd64c26a5ffa27a785782c62b94dL1-R22): Refactored the `properties-to-json` derivation to use `stdenv.mkDerivation`, added dependencies (`python3`, `pandoc`, `makeWrapper`), and included installation and shebang patching steps.
* [`nix/tools/properties-to-json/properties-to-json.py`](diffhunk://#diff-4d345ab4df97aeaf99fbdbf6dfe2b4dd606b72a9a23f0619063abdcad8f217f2R1-R35): Added a new function `html_to_markdown` to convert HTML content to markdown using `pandoc`.
* [`nix/tools/properties-to-json/properties-to-json.py`](diffhunk://#diff-4d345ab4df97aeaf99fbdbf6dfe2b4dd606b72a9a23f0619063abdcad8f217f2R92-R93): Modified the `load_xml_descriptions` function to convert HTML comments to markdown using the new `html_to_markdown` function.