### PR TITLE
autofirma/hm-module: use freeform config for prefs

### DIFF
--- a/nix/autofirma/hm-module.nix
+++ b/nix/autofirma/hm-module.nix
@@ -41,6 +41,8 @@ with lib; let
   boolsToStrings = lib.attrsets.mapAttrs (_: v: if builtins.isBool v then lib.boolToString v else v);
   autofirma-prefs-format = {
     type = types.submodule {
+      freeformType = types.str;
+
       options = lib.attrsets.mapAttrs (_: value: mkOption rec {
         type = if value.default == "true" || value.default == "false" then types.bool else types.str;
         default = if (type == types.bool) then (value.default == "true") else value.default;


### PR DESCRIPTION
Adds a "freeformType" to the programs.autofirma.config submodule,
allowing for arbitrary preferences to be set. Useful e.g. when a new
preference is added that's not part of our default config.

In my case, I use this to set `useDefaultStoreInBrowserCalls` and `defaultLocalKeystorePath` to get a smoother experience with a local PKCS#12 keystore.
