### PR TITLE
fix(autofirma): set explicit permissions on generated cert/pfx

### DIFF
--- a/nix/autofirma/create-autofirma-cert
+++ b/nix/autofirma/create-autofirma-cert
@@ -98,6 +98,17 @@ function do_init {
 		-name "socketautofirma" \
 		-passout pass:654321 \
 		-out "${_autofirma_pfx}"
+        # AutoFirma's own local WebSocket server (AfirmaWebSocketServerManager)
+        # reads this file as whichever unprivileged user invokes AutoFirma from
+        # the browser, but this script is typically run once as root via a
+        # systemd oneshot service (see ../module.nix). The final permissions on
+        # ${_autofirma_pfx} therefore depend entirely on the umask in effect for
+        # that root process, which is not guaranteed to leave the file
+        # world-readable. Set it explicitly rather than relying on the caller's
+        # umask, to avoid a silent, hard-to-diagnose permission-denied failure
+        # (SocketOperationException / SAF_45) the first time a user tries to
+        # sign from a browser.
+        chmod 644 "${_autofirma_ca}" "${_autofirma_pfx}"
 		rm -rf "${_temp_dir}"
 		unset _ca _req _temp_dir
 }


### PR DESCRIPTION
`create-autofirma-cert` is typically run as root via a oneshot systemd service (see `module.nix`), but AutoFirma's local WebSocket server later reads `autofirma.pfx` as an unprivileged user when signing from a browser. The script never set explicit permissions on its output files, so their final mode depended entirely on the umask in effect for the root process at the time it ran. On at least one system this produced `autofirma.pfx` as `0600 root:root`, unreadable by any other user.

The resulting failure is a generic `SocketOperationException` / `SAF_45` in AutoFirma's own log, with no indication that the cause is a file permission on `/etc/Autofirma/autofirma.pfx` -- the underlying `KeyStoreException`/`FileNotFoundException` only appears in `$HOME/.afirma/AUTOFIRMA.afirma.log.xml`, not in the UI-facing error, making this hard to diagnose from the reported symptom alone.

Explicitly chmod both the CA cert and the pfx to `644` at the end of `do_init`, so the result no longer depends on the umask of whatever context invokes this script.

Fixes #986 #685