### PR TITLE
ci: disable stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
-          days-before-issue-stale: 14
-          days-before-issue-close: 7
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."


### PR DESCRIPTION
Our current response time is too long for this to be useful. Disabling it temporarily so as to not having to un-label and/or un-close the issues/PRs that are still relevant.

Not dropping the whole file outright so that actions/stale gets updated by dependabot.